### PR TITLE
ast-ksh: make package needs USE_GCC_RUNTIME=yes to succeed on SmartOS

### DIFF
--- a/shells/ast-ksh/Makefile.common
+++ b/shells/ast-ksh/Makefile.common
@@ -47,6 +47,7 @@ KSH93_MAKEFLAGS+=	CCFLAGS=-lm
 # for things like mamake, ratz and some others for now.
 USE_LANGUAGES+=	c99
 KSH93_MAKEFLAGS+=	LDFLAGS=-lm CCFLAGS="-D_XPG6 -D__EXTENSIONS__"
+USE_GCC_RUNTIME=        yes
 .endif
 
 PKG_SHELL=	bin/ksh93


### PR DESCRIPTION
The package build of shells/ast-ksh fails on SmartOS with
`ERROR: /opt/local/gcc49/lib/amd64/libssp.so.0: gcc49-4.9.3nb1 is not a runtime dependency`
Adding  USE_GCC_RUNTIME=yes to Makefile.common fixes this.
